### PR TITLE
Replace label '-1' to 'Indefinido'

### DIFF
--- a/src/debug.py
+++ b/src/debug.py
@@ -30,7 +30,7 @@ def doc_debug(data_item, out_path):
         n_line = token_box["n_line"]
         label = token_box["label"]
 
-        color = "red" if label != -1 else "black"
+        color = "red" if label != "Indefinido" else "black"
         draw.rectangle(box, outline=color, width=1)
         draw.text(
             (box[0], box[1]),

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,7 +25,7 @@ def cv2pil(cv_image: np.ndarray) -> Image:
 # -------- LABELS------------
 
 def get_label_token(polygon_token, data_item):
-    label_candidates = {'etiqueta': -1, 'perc': -1, 'label': -1}
+    label_candidates = {'etiqueta': -1, 'perc': -1, 'label': 'Indefinido'}
     i=0
     for segmento in data_item['segments']:
         if polygon_token.intersects(segmento['polygon']):


### PR DESCRIPTION
Se reemplaza la etiqueta "-1" por "Indefinido" para los segmentos que no tienen coincidencias en el etiquetado manual.